### PR TITLE
Use compose down, which now removes volumes by default

### DIFF
--- a/core/test/compose/compose.go
+++ b/core/test/compose/compose.go
@@ -29,9 +29,7 @@ func Up(t *testing.T, paths []string, env map[string]string) *tc.LocalDockerComp
 // Down executes compose down.
 func Down(t *testing.T, compose *tc.LocalDockerCompose) {
 	t.Helper()
-	execError := compose.
-		WithCommand([]string{"down", "--volumes"}).
-		Invoke()
+	execError := compose.Down()
 	if err := execError.Error; err != nil {
 		t.Errorf("compose down failed: %v", err)
 		t.FailNow()


### PR DESCRIPTION
https://github.com/testcontainers/testcontainers-go/pull/381 has been merged and released, so now `compose.Down()` removes volumes by default.